### PR TITLE
Allow nested declarations

### DIFF
--- a/syntaxes/aidl.tmLanguage.YAML-tmLanguage
+++ b/syntaxes/aidl.tmLanguage.YAML-tmLanguage
@@ -69,10 +69,6 @@ repository:
   decls:
     patterns:
       - include: '#annotation'
-      - include: '#comments'
-      - include: '#constant_decl'
-      - include: '#method_decl'
-      - include: '#variable_decl'
       - name: punctuation.section.braces.end.aidl
         match: '(\})'
       # interface_decl
@@ -134,6 +130,10 @@ repository:
           '4': {name: entity.name.other.aidl}
           '5': {name: punctuation.definition.generic.end.aidl}
           '6': {name: punctuation.section.braces.begin.aidl}
+      - include: '#comments'
+      - include: '#constant_decl'
+      - include: '#method_decl'
+      - include: '#variable_decl'
   type:
     patterns:
       - include: '#annotation'

--- a/syntaxes/aidl.tmLanguage.YAML-tmLanguage
+++ b/syntaxes/aidl.tmLanguage.YAML-tmLanguage
@@ -69,34 +69,30 @@ repository:
   decls:
     patterns:
       - include: '#annotation'
+      - include: '#comments'
+      - include: '#constant_decl'
+      - include: '#method_decl'
+      - include: '#variable_decl'
+      - name: punctuation.section.braces.end.aidl
+        match: '(\})'
       # interface_decl
       - name: meta.interface.aidl
-        begin: '(?:(oneway)\s+)?(interface)\s+([_a-zA-Z][_a-zA-Z0-9]*)\s*(\{)'
-        beginCaptures:
+        match: '(?:(oneway)\s+)?(interface)\s+([_a-zA-Z][_a-zA-Z0-9]*)\s*(\{)'
+        captures:
           '1': {name: storage.modifier.aidl}
           '2': {name: storage.type.interface.aidl}
           '3': {name: entity.name.type.interface.aidl}
           '4': {name: punctuation.section.braces.begin.aidl}
-        patterns:
-          - include: '#interface_members'
-        end: '(\})'
-        endCaptures:
-          '1': {name: punctuation.section.braces.end.aidl}
       # parcelable_decl
       - name: meta.parcelable.aidl
-        begin: '(parcelable)\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\.([_a-zA-Z][_a-zA-Z0-9]*))*)\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\s*)?(\{)'
-        beginCaptures:
+        match: '(parcelable)\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\.([_a-zA-Z][_a-zA-Z0-9]*))*)\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\s*)?(\{)'
+        captures:
           '1': {name: storage.type.parcelable.aidl}
           '2': {name: entity.name.type.parcelable.aidl}
           '3': {name: punctuation.definition.generic.begin.aidl}
           '4': {name: entity.name.other.aidl}
           '5': {name: punctuation.definition.generic.end.aidl}
           '6': {name: punctuation.section.braces.begin.aidl}
-        patterns:
-          - include: '#parcelable_members'
-        end: '(\})'
-        endCaptures:
-          '1': {name: punctuation.section.braces.end.aidl}
       - name: meta.parcelable.aidl
         match: '(parcelable)\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\.([_a-zA-Z][_a-zA-Z0-9]*))*)\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\s*)?(;)'
         captures:
@@ -130,19 +126,14 @@ repository:
           - include: '#enum_decl_body'
       # union_decl
       - name: meta.union.aidl
-        begin: '(union)\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\.([_a-zA-Z][_a-zA-Z0-9]*))*)\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\s*)?(\{)'
-        beginCaptures:
+        match: '(union)\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\.([_a-zA-Z][_a-zA-Z0-9]*))*)\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\s*)?(\{)'
+        captures:
           '1': {name: storage.type.union.aidl}
           '2': {name: entity.name.type.union.aidl}
           '3': {name: punctuation.definition.generic.begin.aidl}
           '4': {name: entity.name.other.aidl}
           '5': {name: punctuation.definition.generic.end.aidl}
           '6': {name: punctuation.section.braces.begin.aidl}
-        end: '(\})'
-        endCaptures:
-          '1': {name: punctuation.section.braces.end.aidl}
-        patterns:
-          - include: '#parcelable_members'
   type:
     patterns:
       - include: '#annotation'
@@ -172,18 +163,6 @@ repository:
         end: (;)
         endCaptures:
           '1': {name: punctuation.terminator.aidl}
-  interface_members:
-    patterns:
-      - include: '#comments'
-      - include: '#constant_decl'
-      - include: '#method_decl'
-      - include: '#decls'
-  parcelable_members:
-    patterns:
-      - include: '#comments'
-      - include: '#constant_decl'
-      - include: '#variable_decl'
-      - include: '#decls'
   enum_decl_body:
     patterns:
       - include: '#comments'

--- a/syntaxes/aidl.tmLanguage.YAML-tmLanguage
+++ b/syntaxes/aidl.tmLanguage.YAML-tmLanguage
@@ -204,16 +204,15 @@ repository:
       - include: '#type'
       - name: storage.modifier.aidl
         match: oneway
-      - name: entity.name.function.aidl
-        match: '[_a-zA-Z][_a-zA-Z0-9]*'
       - name: keyword.operator.assignment.aidl
         match: =
       - name: punctuation.terminator.aidl
         match: ;
-      - name: meta.function.parameters.aidl
-        begin: (\()
+      - contentName: meta.function.parameters.aidl
+        begin: '([_a-zA-Z][_a-zA-Z0-9]*)\s*(\()'
         beginCaptures:
-          '1': {name: punctuation.definition.parameters.begin.aidl}
+          '1': {name: entity.name.function.aidl}
+          '2': {name: punctuation.definition.parameters.begin.aidl}
         end: (\))
         endCaptures:
           '1': {name: punctuation.definition.parameters.end.aidl}

--- a/syntaxes/aidl.tmLanguage.YAML-tmLanguage
+++ b/syntaxes/aidl.tmLanguage.YAML-tmLanguage
@@ -177,11 +177,13 @@ repository:
       - include: '#comments'
       - include: '#constant_decl'
       - include: '#method_decl'
+      - include: '#decls'
   parcelable_members:
     patterns:
       - include: '#comments'
       - include: '#constant_decl'
       - include: '#variable_decl'
+      - include: '#decls'
   enum_decl_body:
     patterns:
       - include: '#comments'

--- a/syntaxes/aidl.tmLanguage.json
+++ b/syntaxes/aidl.tmLanguage.json
@@ -113,9 +113,25 @@
 					"include": "#annotation"
 				},
 				{
+					"include": "#comments"
+				},
+				{
+					"include": "#constant_decl"
+				},
+				{
+					"include": "#method_decl"
+				},
+				{
+					"include": "#variable_decl"
+				},
+				{
+					"name": "punctuation.section.braces.end.aidl",
+					"match": "(\\})"
+				},
+				{
 					"name": "meta.interface.aidl",
-					"begin": "(?:(oneway)\\s+)?(interface)\\s+([_a-zA-Z][_a-zA-Z0-9]*)\\s*(\\{)",
-					"beginCaptures": {
+					"match": "(?:(oneway)\\s+)?(interface)\\s+([_a-zA-Z][_a-zA-Z0-9]*)\\s*(\\{)",
+					"captures": {
 						"1": {
 							"name": "storage.modifier.aidl"
 						},
@@ -128,23 +144,12 @@
 						"4": {
 							"name": "punctuation.section.braces.begin.aidl"
 						}
-					},
-					"patterns": [
-						{
-							"include": "#interface_members"
-						}
-					],
-					"end": "(\\})",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.section.braces.end.aidl"
-						}
 					}
 				},
 				{
 					"name": "meta.parcelable.aidl",
-					"begin": "(parcelable)\\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\\.([_a-zA-Z][_a-zA-Z0-9]*))*)\\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\\s*)?(\\{)",
-					"beginCaptures": {
+					"match": "(parcelable)\\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\\.([_a-zA-Z][_a-zA-Z0-9]*))*)\\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\\s*)?(\\{)",
+					"captures": {
 						"1": {
 							"name": "storage.type.parcelable.aidl"
 						},
@@ -162,17 +167,6 @@
 						},
 						"6": {
 							"name": "punctuation.section.braces.begin.aidl"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#parcelable_members"
-						}
-					],
-					"end": "(\\})",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.section.braces.end.aidl"
 						}
 					}
 				},
@@ -255,8 +249,8 @@
 				},
 				{
 					"name": "meta.union.aidl",
-					"begin": "(union)\\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\\.([_a-zA-Z][_a-zA-Z0-9]*))*)\\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\\s*)?(\\{)",
-					"beginCaptures": {
+					"match": "(union)\\s+((?:[_a-zA-Z][_a-zA-Z0-9]*)(?:\\.([_a-zA-Z][_a-zA-Z0-9]*))*)\\s*(?:(<)((:?[_a-zA-Z][_a-zA-Z0-9]*)(:?,\\s+[_a-zA-Z][_a-zA-Z0-9]*)*)(>)\\s*)?(\\{)",
+					"captures": {
 						"1": {
 							"name": "storage.type.union.aidl"
 						},
@@ -275,18 +269,7 @@
 						"6": {
 							"name": "punctuation.section.braces.begin.aidl"
 						}
-					},
-					"end": "(\\})",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.section.braces.end.aidl"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#parcelable_members"
-						}
-					]
+					}
 				}
 			]
 		},
@@ -350,38 +333,6 @@
 							"name": "punctuation.terminator.aidl"
 						}
 					}
-				}
-			]
-		},
-		"interface_members": {
-			"patterns": [
-				{
-					"include": "#comments"
-				},
-				{
-					"include": "#constant_decl"
-				},
-				{
-					"include": "#method_decl"
-				},
-				{
-					"include": "#decls"
-				}
-			]
-		},
-		"parcelable_members": {
-			"patterns": [
-				{
-					"include": "#comments"
-				},
-				{
-					"include": "#constant_decl"
-				},
-				{
-					"include": "#variable_decl"
-				},
-				{
-					"include": "#decls"
 				}
 			]
 		},

--- a/syntaxes/aidl.tmLanguage.json
+++ b/syntaxes/aidl.tmLanguage.json
@@ -363,6 +363,9 @@
 				},
 				{
 					"include": "#method_decl"
+				},
+				{
+					"include": "#decls"
 				}
 			]
 		},
@@ -376,6 +379,9 @@
 				},
 				{
 					"include": "#variable_decl"
+				},
+				{
+					"include": "#decls"
 				}
 			]
 		},

--- a/syntaxes/aidl.tmLanguage.json
+++ b/syntaxes/aidl.tmLanguage.json
@@ -113,18 +113,6 @@
 					"include": "#annotation"
 				},
 				{
-					"include": "#comments"
-				},
-				{
-					"include": "#constant_decl"
-				},
-				{
-					"include": "#method_decl"
-				},
-				{
-					"include": "#variable_decl"
-				},
-				{
 					"name": "punctuation.section.braces.end.aidl",
 					"match": "(\\})"
 				},
@@ -270,6 +258,18 @@
 							"name": "punctuation.section.braces.begin.aidl"
 						}
 					}
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#constant_decl"
+				},
+				{
+					"include": "#method_decl"
+				},
+				{
+					"include": "#variable_decl"
 				}
 			]
 		},

--- a/syntaxes/aidl.tmLanguage.json
+++ b/syntaxes/aidl.tmLanguage.json
@@ -427,10 +427,6 @@
 					"match": "oneway"
 				},
 				{
-					"name": "entity.name.function.aidl",
-					"match": "[_a-zA-Z][_a-zA-Z0-9]*"
-				},
-				{
 					"name": "keyword.operator.assignment.aidl",
 					"match": "="
 				},
@@ -439,10 +435,13 @@
 					"match": ";"
 				},
 				{
-					"name": "meta.function.parameters.aidl",
-					"begin": "(\\()",
+					"contentName": "meta.function.parameters.aidl",
+					"begin": "([_a-zA-Z][_a-zA-Z0-9]*)\\s*(\\()",
 					"beginCaptures": {
 						"1": {
+							"name": "entity.name.function.aidl"
+						},
+						"2": {
 							"name": "punctuation.definition.parameters.begin.aidl"
 						}
 					},


### PR DESCRIPTION
AIDL allows interface, parcelable, enum and union declarations to be nested under interface, parcelable and union declarations, so we should too. Due to the limitations of TextMate grammars I've had to be somewhat more liberal in what this accepts; anything that is allowed at the top level will now be allowed within interface, parcelable and union declarations, and vice-versa.

Fixes #2.